### PR TITLE
PoC: decreasing performance load if widget is out of screen

### DIFF
--- a/src/imgui/api.d
+++ b/src/imgui/api.d
@@ -448,6 +448,10 @@ bool imguiBeginScrollArea(const(char)[] title, int xPos, int yPos, int width, in
     g_scrollBottom  = yPos + SCROLL_AREA_PADDING;
     g_scrollRight   = xPos + width - SCROLL_AREA_PADDING * 3;
     g_scrollVal     = scroll;
+    g_state.xorigin = xPos;
+    g_state.yorigin = yPos;
+    g_state.width   = width;
+    g_state.height  = height;
 
     g_scrollAreaTop = g_state.widgetY;
 

--- a/src/imgui/engine.d
+++ b/src/imgui/engine.d
@@ -225,6 +225,9 @@ struct GuiState
 
     uint areaId;
     uint widgetId;
+
+    // size of current renderable area
+    int xorigin, yorigin, width, height;
 }
 
 bool anyActive()

--- a/src/imgui/gl3_renderer.d
+++ b/src/imgui/gl3_renderer.d
@@ -761,7 +761,11 @@ void imguiRenderGLDraw(int width, int height)
         }
         else if (cmd.type == IMGUI_GFXCMD_TEXT)
         {
-            drawText(cmd.text.x, cmd.text.y, cmd.text.text, cmd.text.align_, cmd.col);
+            if ((cmd.text.y >= g_state.yorigin) && (cmd.text.y < (g_state.height+g_state.yorigin)) && 
+                (cmd.text.x >= g_state.xorigin) && (cmd.text.x < (g_state.width+g_state.xorigin)))
+            {
+                drawText(cmd.text.x, cmd.text.y, cmd.text.text, cmd.text.align_, cmd.col);
+            }
         }
         else if (cmd.type == IMGUI_GFXCMD_SCISSOR)
         {


### PR DESCRIPTION
Simple checking if current widget being rendered is in render area to skip those are not in. Am I right that the single point where we can get width and height the area being rendered to is imguiBeginScrollArea?
